### PR TITLE
add the output of the retirement analysis to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 data/*
 output/*
+analysis/maintainer_checkin*/*retiring*.csv
 
 # History files
 .Rhistory


### PR DESCRIPTION
This adds a pattern that will ignore any csv files with "retirement" in the title under
maintainer checkins. 

Moving forward, it would be best to write these data to the `data/` folder with

`here::here("data", paste0(Sys.Date(), "-retiring_maintainers-clean.csv")`

