### PR TITLE
Process retirments

### DIFF
--- a/R/get-gh-token.R
+++ b/R/get-gh-token.R
@@ -8,7 +8,7 @@ damage <- getOption("modify.maintainer.permissions", default = FALSE)
 if (damage) {
   message("CAUTION: This token has write access to any organisations you have control of.")
 }
-scopes <- c("public_repo", "read:org", if (damage) "write:org" else NULL)
+scopes <- c("public_repo", if (damage) "admin:org" else "read:org")
 desc <- if (damage) "DANGER%20Write%20" else "Read%20"
 url <- "https://github.com/settings/tokens/new?scopes=%s&description=%sCarpentries%%20Data"
 browseURL(sprintf(url, paste(scopes, collapse = ","), desc))

--- a/R/get-gh-token.R
+++ b/R/get-gh-token.R
@@ -1,0 +1,21 @@
+library("clipr")
+library("askpass")
+
+# step 1: create a throwaway github token ----------------------------------------
+# 
+# This opens a browser window with a token that allows you to read organisation information.
+damage <- getOption("modify.maintainer.permissions", default = FALSE)
+if (damage) {
+  message("CAUTION: This token has write access to any organisations you have control of.")
+}
+scopes <- c("public_repo", "read:org", if (damage) "write:org" else NULL)
+desc <- if (damage) "DANGER%20Write%20" else "Read%20"
+url <- "https://github.com/settings/tokens/new?scopes=%s&description=%sCarpentries%%20Data"
+browseURL(sprintf(url, paste(scopes, collapse = ","), desc))
+
+## Step 2: save the token for use here ---------------------------------------------
+#You should copy and paste the token in your prompt after running this command. 
+Sys.setenv("GITHUB_TOKEN" = askpass::askpass("Copy and past your Github PAT:\n"))
+message("clearing the token from your clipboard")
+clipr::write_clip("[deleted]")
+

--- a/R/get-teams.R
+++ b/R/get-teams.R
@@ -1,20 +1,14 @@
 library("gh")
+library("here")
 library("purrr")
 library("jsonlite")
-library("askpass")
 
 # step 1: create a throwaway github token ----------------------------------------
 # 
 # This opens a browser window with a token that allows you to read organisation information.
+source(here::here("R", "get-gh-token.R"))
 
-url <- "https://github.com/settings/tokens/new?scopes=public_repo,read:org&description='Read org data'"
-browseURL(url)
-
-## Step 2: save the token for use here ---------------------------------------------
-#You should copy and paste the token in your prompt after running this command. 
-Sys.setenv("GITHUB_TOKEN" = askpass::askpass("Copy and past your Github PAT:\n"))
-
-# Step 3: get the repositories and use the GitHub API to get the teams from the repositories
+# Step 2: get the repositories and use the GitHub API to get the teams from the repositories
 
 # Get teams for curriculum
 get_teams_for_repo <- function(repo) {
@@ -31,4 +25,8 @@ repos <- purrr::map_chr(lessons_json, ~paste0(.x$carpentries_org, "/", .x$repo))
 teams <- get_teams(repos)
 names(teams) <- repos
 
-# Step 4: ... map members to teams and remove needed members. 
+out <- here::here("data", "teams.json")
+message("writing teams data to", out)
+jsonlite::write_json(teams, out)
+rm(teams)
+

--- a/analysis/maintainer_checkin_2022/merge-amy-data.R
+++ b/analysis/maintainer_checkin_2022/merge-amy-data.R
@@ -1,0 +1,19 @@
+library("readr")
+library("dplyr")
+amy <- readr::read_csv(here::here("data", "2022-04-07-maintainers-from-amy.csv"))
+manual <- readr::read_csv(here::here("data", "2022-04-07-retired-maintainers.csv"))
+
+no_gh <- manual |>
+  select(email_clean, gh_name_clean) |>
+  filter(is.na(gh_name_clean) & !is.na(email_clean)) |>
+  distinct()
+
+no_nothing <- manual |>
+  select(Name, email_clean, gh_name_clean) |>
+  filter(is.na(gh_name_clean), is.na(email_clean)) |>
+  distinct()
+
+inner_join(no_gh, amy, by = c("email_clean" = "person_email"), na_match = "never")
+inner_join(no_gh, amy, by = c("email_clean" = "person_secondary_email"), na_match = "never")
+
+inner_join(no_nothing, amy, by = c("Name" = "person_name"), na_match = "never")

--- a/analysis/maintainer_checkin_2022/merge-amy-data.R
+++ b/analysis/maintainer_checkin_2022/merge-amy-data.R
@@ -13,7 +13,10 @@ no_nothing <- manual |>
   filter(is.na(gh_name_clean), is.na(email_clean)) |>
   distinct()
 
-inner_join(no_gh, amy, by = c("email_clean" = "person_email"), na_match = "never")
+gh_by_email <- bind_rows(
+inner_join(no_gh, amy, by = c("email_clean" = "person_email"), na_match = "never"),
 inner_join(no_gh, amy, by = c("email_clean" = "person_secondary_email"), na_match = "never")
+)
 
-inner_join(no_nothing, amy, by = c("Name" = "person_name"), na_match = "never")
+gh_by_name <- inner_join(no_nothing, amy, by = c("Name" = "person_name"), na_match = "never")
+

--- a/analysis/maintainer_checkin_2022/update-maintainers-github.R
+++ b/analysis/maintainer_checkin_2022/update-maintainers-github.R
@@ -1,0 +1,73 @@
+library("gh")
+library("here")
+library("cli")
+library("jsonlite")
+
+options(modify.maintainer.permissions = FALSE)
+on.exit(Sys.setenv(GITHUB_TOKEN = NULL))
+source(here::here("R", "get-teams.R"))
+
+fix_repo_names <- function(repos) {
+  for (i in seq(repos)) {
+    repo <- repos[i]
+    if (is.na(repo)) next
+    repos[i] <- tolower(if (endsWith(repo, "/")) repo else paste0(repo, "/"))
+  }
+  repos
+}
+
+get_maintainer_team <- function(teams) {
+  team_names <- purrr::keep(teams, ~grepl("maintainer", .x$slug[[1]]))
+  if (length(team_names)) team_names[[1]] else NULL
+}
+
+username_in_team <- function(member, team) {
+  url <- paste0(team$url[[1]], "/members/", member)
+  res <- tryCatch(gh::gh(url),
+    github_error = function(e) {
+      if (inherits(e, "http_error_404")) {
+        # when we get a 404 here, that means the user does not exist
+        return(FALSE)
+      } else {
+        stop(e)
+      }
+    }
+  )
+  if (length(res)) return(res) else return(TRUE)
+}
+
+remove_username_from_teams <- function(username, repo, teams) {
+  for (team in teams) {
+    team_slug <- team$slug[[1]]
+    if (username_in_team(username, team)) {
+      cli_alert_success("SUCCESS! {.strong {username}} is a member of {.strong {team_slug}}")
+      org <- strsplit(repo, "/")[[1]][1]
+      deeleet <- "DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"
+      cli_alert_info("Running {.code DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}}")
+      # gh::gh(deeleet, org = org, team_slug = team_slug, username = username)
+      
+    } else {
+      cli_alert_danger("{.emph (屮ﾟДﾟ)屮 {.strong {username}} is not a member of {.strong {team_slug}}}")
+    }
+  }
+}
+
+teams <- jsonlite::read_json(here::here("data", "teams.json"))
+names(teams) <- fix_repo_names(names(teams))
+maintainer_teams <- purrr::map(teams, get_maintainer_team) 
+retirement <- read.csv(here::here("analysis", "maintainer_checkin_2022", "2022-03-21-retiring_maintainers-clean.csv"))
+user_repo <- retirement[c("gh_name_clean", "gh_text")]
+user_repo$gh_text <- fix_repo_names(user_repo$gh_text)
+
+
+
+for (i in seq(nrow(user_repo))) {
+  this_repo <- user_repo$gh_text[i]
+  this_user <- user_repo$gh_name_clean[i]
+  if (this_repo %in% names(teams)) {
+    remove_username_from_teams(this_user, this_repo, teams[[this_repo]])
+  } else {
+    cli_alert_warning(sprintf("%s is not a lesson repository", this_repo))
+  }
+}
+

--- a/analysis/maintainer_checkin_2022/update-maintainers-github.R
+++ b/analysis/maintainer_checkin_2022/update-maintainers-github.R
@@ -1,9 +1,11 @@
 library("gh")
 library("here")
+library("dplyr")
+library("purrr")
 library("cli")
 library("jsonlite")
 
-options(modify.maintainer.permissions = FALSE)
+options(modify.maintainer.permissions = TRUE)
 on.exit(Sys.setenv(GITHUB_TOKEN = NULL))
 if (file.exists(here::here("data", "teams.json"))) {
   source(here::here("R", "get-gh-token.R"))
@@ -20,9 +22,8 @@ fix_repo_names <- function(repos) {
   repos
 }
 
-get_maintainer_team <- function(teams) {
-  team_names <- purrr::keep(teams, ~grepl("maintainer", .x$slug[[1]]))
-  if (length(team_names)) team_names[[1]] else NULL
+get_org_names <- function(repos) {
+  purrr::map_chr(repos, ~strsplit(.x, "/")[[1]][1])
 }
 
 username_in_team <- function(member, team) {
@@ -40,40 +41,71 @@ username_in_team <- function(member, team) {
   if (length(res)) return(res) else return(TRUE)
 }
 
-remove_username_from_teams <- function(username, repo, teams) {
-  danger_scope <- grepl("admin:org", gh::gh_whoami()$scopes)
-  for (team in teams) {
-    team_slug <- team$slug[[1]]
-    if (username_in_team(username, team)) {
-      cli_alert_success("SUCCESS! {.strong {username}} is a member of {.strong {team_slug}}")
-      if (danger_scope) {
-        org <- strsplit(repo, "/")[[1]][1]
-        deeleet <- "DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"
-        cli_alert_info("Running {.code DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}}")
-        gh::gh(deeleet, org = org, team_slug = team_slug, username = username)
-      }
-    } else {
-      cli_alert_danger("{.emph (屮ﾟДﾟ)屮 {.strong {username}} is not a member of {.strong {team_slug}}}")
+remove_username_from_team <- function(username, team, delete = FALSE) {
+  org <- team$org
+  team_slug <- team$slug[[1]]
+  if (username_in_team(username, team)) {
+    cli_alert_success("{.strong {username}} is a member of {.strong {team_slug}}")
+    if (delete) {
+      deeleet <- "DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"
+      cli_alert_info("Running DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}")
+      gh::gh(deeleet, org = org, team_slug = team_slug, username = username)
     }
+    status <- "removed"
+  } else {
+    noh <- "{.emph {.strong {username}} is not a member of {.strong {team_slug}}}"
+    cli_alert_danger(noh)
+    status <- NA
   }
+  return(list(username = username, team_slug = team_slug, team_org = org, 
+    team_status = status))
 }
 
+remove_username_from_all_teams <- function(username, teams, delete = FALSE) {
+  res <- purrr::map(teams, ~remove_username_from_team(username, .x, delete = delete))
+  dplyr::bind_rows(res[lengths(res) > 0])
+}
+
+
+# read in team data from stored json file and filter into a list with all teams
+# that are not bots, the core team, staff teams, or curriculum advisors
 teams <- jsonlite::read_json(here::here("data", "teams.json"))
 names(teams) <- fix_repo_names(names(teams))
-maintainer_teams <- purrr::map(teams, get_maintainer_team) 
-retirement <- read.csv(here::here("analysis", "maintainer_checkin_2022", "2022-03-21-retiring_maintainers-clean.csv"))
-user_repo <- retirement[c("gh_name_clean", "gh_text")]
-user_repo$gh_text <- fix_repo_names(user_repo$gh_text)
+all_orgs <- rep(get_org_names(names(teams)), lengths(teams))
+all_teams <- purrr::flatten(teams) |> 
+  purrr::map2(all_orgs, function(x, y) modifyList(x, list(org = y)))
+names(all_teams) <- purrr::map_chr(all_teams, list("slug", 1))
+team_filter <- !grepl("bots|core|staff|curriculum-advis", names(all_teams)) &
+  !duplicated(names(all_teams))
+all_teams <- all_teams[team_filter]
+stopifnot(
+  "core-team is in teams" = !"core-team" %in% names(all_teams),
+  "curriculum advisors is in teams" = !grepl("curriculum-advis", names(all_teams)),
+  "bots is in teams" = !grepl("bots", names(all_teams)),
+  "staff is in teams" = !grepl("staff", names(all_teams))
+)
 
+retirement <- readr::read_csv(here::here("analysis", "maintainer_checkin_2022", "2022-03-21-retiring_maintainers-clean.csv"))
 
+retiring_maintainers <- dplyr::filter(retirement, 
+  Status == "Retire" & !duplicated(gh_name_clean)) 
+stopifnot(
+  "tally not correct" = nrow(retiring_maintainers) == 43
+)
+danger_scope <- grepl("admin:org", gh::gh_whoami()$scopes)
 
-for (i in seq(nrow(user_repo))) {
-  this_repo <- user_repo$gh_text[i]
-  this_user <- user_repo$gh_name_clean[i]
-  if (this_repo %in% names(teams)) {
-    remove_username_from_teams(this_user, this_repo, teams[[this_repo]])
-  } else {
-    cli_alert_warning(sprintf("%s is not a lesson repository", this_repo))
-  }
-}
+# Check each github name of officially retiring maintainers against 
+status <- purrr::map_dfr(retiring_maintainers$gh_name_clean, 
+  ~remove_username_from_all_teams(.x, all_teams, delete = danger_scope))
+
+# bring it all into a spreadsheet. 
+# NOTE: there is duplication because the `gh_text` feild was the repository, but
+# we needed to remove them from teams, which is what we did here.
+#
+# If any maintainer was not on any team, their status would show up as NA here.
+updated <- dplyr::full_join(retirement, status |> dplyr::filter(!is.na(team_status)), 
+  by = c("gh_name_clean" = "username")) |> dplyr::distinct()
+
+readr::write_csv(updated, file = here::here("data", "2022-04-07-retired-maintainers.csv"))
+
 

--- a/analysis/maintainer_checkin_2022/update-nonresponse-maintainer-github.R
+++ b/analysis/maintainer_checkin_2022/update-nonresponse-maintainer-github.R
@@ -1,0 +1,117 @@
+library("gh")
+library("here")
+library("dplyr")
+library("purrr")
+library("cli")
+library("jsonlite")
+
+options(modify.maintainer.permissions = FALSE)
+on.exit(Sys.setenv(GITHUB_TOKEN = NULL))
+if (file.exists(here::here("data", "teams.json"))) {
+  source(here::here("R", "get-gh-token.R"))
+} else {
+  source(here::here("R", "get-teams.R"))
+}
+
+fix_repo_names <- function(repos) {
+  for (i in seq(repos)) {
+    repo <- repos[i]
+    if (is.na(repo)) next
+    repos[i] <- tolower(if (endsWith(repo, "/")) repo else paste0(repo, "/"))
+  }
+  repos
+}
+
+get_org_names <- function(repos) {
+  purrr::map_chr(repos, ~strsplit(.x, "/")[[1]][1])
+}
+
+username_in_team <- function(member, team) {
+  url <- paste0(team$url[[1]], "/members/", member)
+  res <- tryCatch(gh::gh(url),
+    github_error = function(e) {
+      if (inherits(e, "http_error_404")) {
+        # when we get a 404 here, that means the user does not exist
+        return(FALSE)
+      } else {
+        stop(e)
+      }
+    }
+  )
+  if (length(res)) return(res) else return(TRUE)
+}
+
+remove_username_from_team <- function(username, team, delete = FALSE) {
+  org <- team$org
+  team_slug <- team$slug[[1]]
+  if (username_in_team(username, team)) {
+    cli_alert_success("{.strong {username}} is a member of {.strong {team_slug}}")
+    if (delete) {
+      deeleet <- "DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}"
+      cli_alert_info("Running DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}")
+      gh::gh(deeleet, org = org, team_slug = team_slug, username = username)
+    }
+    status <- "removed"
+  } else {
+    noh <- "{.emph {.strong {username}} is not a member of {.strong {team_slug}}}"
+    cli_alert_danger(noh)
+    status <- NA
+  }
+  return(list(username = username, team_slug = team_slug, team_org = org, 
+    team_status = status))
+}
+
+remove_username_from_all_teams <- function(username, teams, delete = FALSE) {
+  res <- purrr::map(teams, ~remove_username_from_team(username, .x, delete = delete))
+  dplyr::bind_rows(res[lengths(res) > 0])
+}
+
+
+# read in team data from stored json file and filter into a list with all teams
+# that are not bots, the core team, staff teams, or curriculum advisors
+teams <- jsonlite::read_json(here::here("data", "teams.json"))
+names(teams) <- fix_repo_names(names(teams))
+all_orgs <- rep(get_org_names(names(teams)), lengths(teams))
+all_teams <- purrr::flatten(teams) |> 
+  purrr::map2(all_orgs, function(x, y) modifyList(x, list(org = y)))
+names(all_teams) <- purrr::map_chr(all_teams, list("slug", 1))
+team_filter <- !grepl("bots|core|staff|curriculum-advis", names(all_teams)) &
+  !duplicated(names(all_teams))
+all_teams <- all_teams[team_filter]
+stopifnot(
+  "core-team is in teams" = !"core-team" %in% names(all_teams),
+  "curriculum advisors is in teams" = !grepl("curriculum-advis", names(all_teams)),
+  "bots is in teams" = !grepl("bots", names(all_teams)),
+  "staff is in teams" = !grepl("staff", names(all_teams))
+)
+
+retirement <- readr::read_csv(here::here("data", "2022-inactive.csv"))
+
+retiring_maintainers <- dplyr::filter(retirement, 
+  status == "Unresponsive" & !is.na(github)) |>
+  dplyr::distinct(github)
+
+# Check each github name of officially retiring maintainers against 
+status <- purrr::map_dfr(retiring_maintainers$github,
+  ~remove_username_from_all_teams(.x, all_teams, delete = FALSE))
+
+# redo scope
+options(modify.maintainer.permissions = TRUE)
+on.exit(Sys.setenv(GITHUB_TOKEN = NULL))
+source(here::here("R", "get-gh-token.R"))
+
+danger_scope <- grepl("admin:org", gh::gh_whoami()$scopes)
+final_status <- status |>
+ dplyr::filter(!is.na(team_status)) |>
+ mutate(team = all_teams[team_slug]) |>
+ dplyr::rowwise() |>
+ dplyr::summarise(res = data.frame(
+   remove_username_from_team(username = username, team = team, delete = danger_scope))) |>
+ tidyr::unnest(cols = res)
+
+# bring it all into a spreadsheet. 
+# NOTE: there is duplication because the `gh_text` feild was the repository, but
+# we needed to remove them from teams, which is what we did here.
+#
+
+


### PR DESCRIPTION
WIP processing of retirements.

Right now, this processes retirements for self-reported lessons, but some maintainers have access to multiple lessons that they did not report. Instead of relying on a repo-based retirement, we will instead check membership status for each team and remove them from any team that is not associated with core team, bots, or curriculum advisors.